### PR TITLE
Use kolmafia-types instead of kolmafia-js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use kolmafia-types instead of kolmafia-js.
+  Also, this is now a dev-only dependency. (#2)
+
 ## [0.1.1] - 2020-12-24
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1559,9 +1559,10 @@
       "dev": true
     },
     "kolmafia": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/kolmafia/-/kolmafia-1.0.3.tgz",
-      "integrity": "sha512-e9H+mhYP/xqhfX56AcbVtc5aIsrWbH2LHNQoG5S2i5k0ST4NaMoIQLxBpkFxPs1rUjHPNDcqxxN1McPviqm/BQ=="
+      "version": "npm:kolmafia-types@0.0.3",
+      "resolved": "https://registry.npmjs.org/kolmafia-types/-/kolmafia-types-0.0.3.tgz",
+      "integrity": "sha512-Rj8G55M86MYKzGge58jKr87Mbe/7miuvs1d7kiAEJ/zOUwchTeRxBlwwHthIvNEu6WmMtlQ0oMrBD34JygGoQw==",
+      "dev": true
     },
     "latest-version": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -34,12 +34,11 @@
     "@types/node": "^14.11.2",
     "gts": "^3.0.3",
     "jasmine": "^3.6.3",
+    "kolmafia": "npm:kolmafia-types@0.0.3",
     "mock-require": "^3.0.3",
     "typescript": "^4.1.3"
   },
-  "dependencies": {
-    "kolmafia": "^1.0.3"
-  },
+  "dependencies": {},
   "files": [
     "build/src/**/*",
     "build/esm/src/**/*.js",


### PR DESCRIPTION
Note: kolmafia-types is a development-only dependency.

Back when I added kolmafia-js in 8617a47c80aff2b1315d7133017f54ed0973ad22, I worried that I might need to use types from kolmafia-js. Since such a thing has not happened yet, I think it's safe to add kolmafia-types to `devDependencies`.