### PR TITLE
test: Use testdouble instead of mock-require

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,10 @@
       "license": "MIT",
       "devDependencies": {
         "@types/jasmine": "^3.6.10",
-        "@types/mock-require": "^2.0.0",
         "gts": "^3.1.0",
         "jasmine": "^3.7.0",
         "kolmafia": "npm:kolmafia-types@^0.1.0",
-        "mock-require": "^3.0.3",
+        "testdouble": "^3.16.1",
         "ts-node": "^10.0.0",
         "typescript": "^4.2.4"
       }
@@ -239,20 +238,12 @@
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
       "dev": true
     },
-    "node_modules/@types/mock-require": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mock-require/-/mock-require-2.0.0.tgz",
-      "integrity": "sha512-nOgjoE5bBiDeiA+z41i95makyHUSMWQMOPocP+J67Pqx/68HAXaeWN1NFtrAYYV6LrISIZZ8vKHm/a50k0f6Sg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "15.12.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
       "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1626,12 +1617,6 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "node_modules/get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-      "dev": true
-    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -2111,6 +2096,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -2500,19 +2494,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/mock-require": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-3.0.3.tgz",
-      "integrity": "sha512-lLzfLHcyc10MKQnNUCv7dMcoY/2Qxd6wJfbqCcVk3LDb8An4hF6ohk5AztrvgKhJCqj36uyzi/p5se+tvyD+Wg==",
-      "dev": true,
-      "dependencies": {
-        "get-caller-file": "^1.0.2",
-        "normalize-path": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=4.3.0"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2553,18 +2534,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "dependencies": {
-        "remove-trailing-separator": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/normalize-url": {
@@ -2893,6 +2862,20 @@
         }
       ]
     },
+    "node_modules/quibble": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.5.tgz",
+      "integrity": "sha512-L3/bDHWjHm9zdG0Aqj7lhmp6Q5RFjXeitO9CGzWKP83d6BlGS0lLo9oswxgq62gwuIF7apT9tO0dw9kNuvb9eg==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14",
+        "resolve": "^1.11.1"
+      },
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
     "node_modules/quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -3057,12 +3040,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -3352,6 +3329,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/stringify-object-es5": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+      "integrity": "sha1-BXw8mpChJzObudFwSikLt70KHsU=",
+      "dev": true,
+      "dependencies": {
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -3448,10 +3438,31 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "node_modules/testdouble": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.1.tgz",
+      "integrity": "sha512-diaNYjFfR8bdMhtwJ9c2KxHa7M8Al7YciU+kteutWIIendmCC61ZyqQBtprsFkb6Cd/rjBr2sEoUJ8bWIVHm6w==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "quibble": "^0.6.4",
+        "stringify-object-es5": "^2.5.0",
+        "theredoc": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "node_modules/theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
       "dev": true
     },
     "node_modules/through": {
@@ -3978,20 +3989,12 @@
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
       "dev": true
     },
-    "@types/mock-require": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mock-require/-/mock-require-2.0.0.tgz",
-      "integrity": "sha512-nOgjoE5bBiDeiA+z41i95makyHUSMWQMOPocP+J67Pqx/68HAXaeWN1NFtrAYYV6LrISIZZ8vKHm/a50k0f6Sg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
       "version": "15.12.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
       "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -4991,12 +4994,6 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-      "dev": true
-    },
     "get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -5345,6 +5342,12 @@
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
+    },
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -5651,16 +5654,6 @@
         "kind-of": "^6.0.3"
       }
     },
-    "mock-require": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-3.0.3.tgz",
-      "integrity": "sha512-lLzfLHcyc10MKQnNUCv7dMcoY/2Qxd6wJfbqCcVk3LDb8An4hF6ohk5AztrvgKhJCqj36uyzi/p5se+tvyD+Wg==",
-      "dev": true,
-      "requires": {
-        "get-caller-file": "^1.0.2",
-        "normalize-path": "^2.1.1"
-      }
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5695,15 +5688,6 @@
         "resolve": "^1.20.0",
         "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-url": {
@@ -5930,6 +5914,16 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "quibble": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.5.tgz",
+      "integrity": "sha512-L3/bDHWjHm9zdG0Aqj7lhmp6Q5RFjXeitO9CGzWKP83d6BlGS0lLo9oswxgq62gwuIF7apT9tO0dw9kNuvb9eg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14",
+        "resolve": "^1.11.1"
+      }
+    },
     "quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -6058,12 +6052,6 @@
       "requires": {
         "rc": "^1.2.8"
       }
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -6280,6 +6268,16 @@
         "strip-ansi": "^6.0.0"
       }
     },
+    "stringify-object-es5": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+      "integrity": "sha1-BXw8mpChJzObudFwSikLt70KHsU=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -6353,10 +6351,28 @@
         }
       }
     },
+    "testdouble": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.1.tgz",
+      "integrity": "sha512-diaNYjFfR8bdMhtwJ9c2KxHa7M8Al7YciU+kteutWIIendmCC61ZyqQBtprsFkb6Cd/rjBr2sEoUJ8bWIVHm6w==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15",
+        "quibble": "^0.6.4",
+        "stringify-object-es5": "^2.5.0",
+        "theredoc": "^1.0.0"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
       "dev": true
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -34,11 +34,10 @@
   },
   "devDependencies": {
     "@types/jasmine": "^3.6.10",
-    "@types/mock-require": "^2.0.0",
     "gts": "^3.1.0",
     "jasmine": "^3.7.0",
     "kolmafia": "npm:kolmafia-types@^0.1.0",
-    "mock-require": "^3.0.3",
+    "testdouble": "^3.16.1",
     "ts-node": "^10.0.0",
     "typescript": "^4.2.4"
   }

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -1,6 +1,6 @@
-import mock = require('mock-require');
+import td = require('testdouble');
 
-mock('kolmafia', {
+td.replace('kolmafia', {
   getRevision: () => 20000,
   getVersion: () => 'KoLmafia v15.3',
 });


### PR DESCRIPTION
Replace [mock-require](https://github.com/boblauer/mock-require) (which has ceased development) with [testdouble](https://github.com/testdouble/testdouble.js).
Since testdouble supports native ESM mocking as well, this will reduce future friction should we choose to emit native ESM by default.