### PR TITLE
feat!: Add assertion library

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,86 @@ const someValue = withOutfitCheckpoint(() => {
   return someValue;
 });
 ```
+
+### Assertion Library
+
+kolmafia-util exports a rudimentary assertion library. To import it, use:
+
+```ts
+import * as assert from 'kolmafia-util/assert';
+
+assert.ok(someValue());
+```
+
+Note that the assertion library do not rely on KoLmafia's library functions. This makes them runnable in almost any JavaScript environment.
+
+### `ok(cond, [message])`
+
+Asserts that a condition is truthy. This also acts as a TypeScript type assertion, and can participate in type narrowing.
+
+```ts
+const a: string | null = getSomething();
+assert.ok(a, 'a is falsy');
+// This works because assert.ok() narrows the type of a to a string.
+const b = a.toLowerCase();
+```
+
+### `fail([message])`
+
+Throws an error, optionally with the given message.
+
+```ts
+assert.fail('This should be unreachable');
+```
+
+### `equal(actual, expected, [message])`
+
+Asserts that `actual` is strictly equal (`===`) to `expected`.
+
+```ts
+assert.equal(someValue(), 'FOO');
+```
+
+### `notEqual(actual, expected, [message])`
+
+Asserts that `actual` is strictly inequal (`!==`) to `expected`.
+
+```ts
+assert.notEqual(someValue(), null);
+```
+
+### `isAtLeast(actual, expected, [message])`
+
+Asserts that `actual` is greater than or equal (`>=`) to `expected`.
+
+```ts
+assert.isAtLeast(someValue(), 50);
+```
+
+### `isAtMost(actual, expected, [message])`
+
+Asserts that `actual` is less than or equal (`>=`) to `expected`.
+
+```ts
+assert.isAtMost(someValue(), 50);
+```
+
+### `isAbove(actual, expected, [message])`
+
+Asserts that `actual` is greater than (`>`) `expected`.
+
+```ts
+assert.isAbove(someValue(), 50);
+```
+
+### `isBelow(actual, expected, [message])`
+
+Asserts that `actual` is less than (`<`) `expected`.
+
+```ts
+assert.isBelow(someValue(), 50);
+```
+
+### `AssertionError`
+
+An error class that is thrown by the assertion functions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@rollup/plugin-buble": "^0.21.3",
         "@rollup/plugin-typescript": "^8.2.1",
         "@types/jasmine": "^3.6.10",
+        "@types/node": "^12.20.16",
         "buble-config-rhino": "^0.1.0",
         "gts": "^3.1.0",
         "husky": "^6.0.0",
@@ -25,6 +26,9 @@
         "ts-node": "^10.0.0",
         "tslib": "^2.3.0",
         "typescript": "^4.2.4"
+      },
+      "engines": {
+        "node": ">= 12.16.0 || >= 13.7.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -562,11 +566,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.1.tgz",
-      "integrity": "sha512-N87VuQi7HEeRJkhzovao/JviiqKjDKMVKxKMfUvSKw+MbkbW8R0nA3fi/MQhhlxV2fQ+2ReM+/Nt4efdrJx3zA==",
-      "dev": true,
-      "peer": true
+      "version": "12.20.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
+      "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -6348,11 +6351,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.1.tgz",
-      "integrity": "sha512-N87VuQi7HEeRJkhzovao/JviiqKjDKMVKxKMfUvSKw+MbkbW8R0nA3fi/MQhhlxV2fQ+2ReM+/Nt4efdrJx3zA==",
-      "dev": true,
-      "peer": true
+      "version": "12.20.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
+      "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,26 @@
   },
   "license": "MIT",
   "author": "Ye-hyoung Kang",
-  "main": "build/cjs/index.js",
-  "module": "build/esm/index.js",
-  "types": "build/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./build/esm/index.js",
+      "require": "./build/cjs/index.js"
+    },
+    "./assert": {
+      "import": "./build/esm/assert/index.js",
+      "require": "./build/cjs/assert/index.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "assert": [
+        "build/esm/assert/index.d.ts"
+      ],
+      "*": [
+        "build/esm/*"
+      ]
+    }
+  },
   "files": [
     "build"
   ],
@@ -38,6 +55,7 @@
     "@rollup/plugin-buble": "^0.21.3",
     "@rollup/plugin-typescript": "^8.2.1",
     "@types/jasmine": "^3.6.10",
+    "@types/node": "^12.20.16",
     "buble-config-rhino": "^0.1.0",
     "gts": "^3.1.0",
     "husky": "^6.0.0",
@@ -49,5 +67,8 @@
     "ts-node": "^10.0.0",
     "tslib": "^2.3.0",
     "typescript": "^4.2.4"
+  },
+  "engines": {
+    "node": ">= 12.16.0 || >= 13.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   },
   "license": "MIT",
   "author": "Ye-hyoung Kang",
-  "main": "build/index.js",
+  "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
-  "types": "build/index.d.ts",
+  "types": "build/esm/index.d.ts",
   "files": [
     "build"
   ],

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,14 +1,24 @@
 import buble from '@rollup/plugin-buble';
 import typescript from '@rollup/plugin-typescript';
 import createBubleConfig from 'buble-config-rhino';
+import * as path from 'path';
 import type {RollupOptions} from 'rollup';
 
 function createConfig(format: 'cjs' | 'esm'): RollupOptions {
   return {
     external: ['kolmafia'],
-    input: 'src/index.ts',
+    input: ['src/index.ts', 'src/assert/index.ts'],
     output: {
       dir: `build/${format}`,
+      entryFileNames: chunkInfo => {
+        // Emit output chunks according to their relative paths of the entry
+        // points in the source dir
+        if (!chunkInfo.facadeModuleId) throw new Error('No facadeModuleId');
+        return path.join(
+          path.relative('src', path.dirname(chunkInfo.facadeModuleId)),
+          '[name].js'
+        );
+      },
       format,
       sourcemap: true,
     },

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,38 +1,22 @@
 import buble from '@rollup/plugin-buble';
 import typescript from '@rollup/plugin-typescript';
-import createConfig from 'buble-config-rhino';
+import createBubleConfig from 'buble-config-rhino';
 import type {RollupOptions} from 'rollup';
 
-const baseConfig: RollupOptions = {
-  external: ['kolmafia'],
-  input: 'src/index.ts',
-};
-
-const config: RollupOptions[] = [
-  {
-    ...baseConfig,
+function createConfig(format: 'cjs' | 'esm'): RollupOptions {
+  return {
+    external: ['kolmafia'],
+    input: 'src/index.ts',
     output: {
-      dir: 'build',
-      format: 'cjs',
+      dir: `build/${format}`,
+      format,
       sourcemap: true,
     },
     plugins: [
-      buble(createConfig()),
-      typescript({tsconfig: 'src/tsconfig.json'}),
+      buble(createBubleConfig()),
+      typescript({outDir: `build/${format}`, tsconfig: 'src/tsconfig.json'}),
     ],
-  },
-  {
-    ...baseConfig,
-    output: {
-      dir: 'build/esm',
-      format: 'esm',
-      sourcemap: true,
-    },
-    plugins: [
-      buble(createConfig()),
-      typescript({outDir: 'build/esm', tsconfig: 'src/tsconfig.json'}),
-    ],
-  },
-];
+  };
+}
 
-export default config;
+export default [createConfig('cjs'), createConfig('esm')];

--- a/spec/assert.spec.ts
+++ b/spec/assert.spec.ts
@@ -1,0 +1,139 @@
+import * as assert from '../src/assert';
+
+describe('assert.ok()', () => {
+  it('should not throw on truthy values', () => {
+    expect(() => assert.ok(true)).not.toThrow();
+    expect(() => assert.ok(1)).not.toThrow();
+    expect(() => assert.ok({})).not.toThrow();
+    expect(() => assert.ok([])).not.toThrow();
+    expect(() => assert.ok(/foo/)).not.toThrow();
+  });
+
+  it('should throw on falsy values', () => {
+    expect(() => assert.ok(false)).toThrowError(assert.AssertionError);
+    expect(() => assert.ok(0)).toThrowError(assert.AssertionError);
+    expect(() => assert.ok(undefined)).toThrowError(assert.AssertionError);
+    expect(() => assert.ok(null)).toThrowError(assert.AssertionError);
+    expect(() => assert.ok(NaN)).toThrowError(assert.AssertionError);
+  });
+});
+
+describe('assert.fail()', () => {
+  it('should throw', () => {
+    expect(() => assert.fail()).toThrowError(assert.AssertionError);
+    expect(() => assert.fail('foo bar')).toThrowError(
+      assert.AssertionError,
+      'foo bar'
+    );
+  });
+});
+
+describe('assert.equal()', () => {
+  it('should not throw if a === b', () => {
+    expect(() => assert.equal('foo', 'foo')).not.toThrow();
+  });
+
+  it('should throw if a !== b', () => {
+    expect(() => assert.equal(1, 2)).toThrowError(assert.AssertionError);
+    expect(() => assert.equal(NaN, NaN)).toThrowError(assert.AssertionError);
+  });
+
+  it('should compare shallowly', () => {
+    expect(() => assert.equal({}, {})).toThrowError(assert.AssertionError);
+    expect(() => assert.equal([1, 2, 3], [1, 2, 3])).toThrowError(
+      assert.AssertionError
+    );
+  });
+});
+
+describe('assert.notEqual()', () => {
+  it('should not throw if a !== b', () => {
+    expect(() => assert.notEqual(100, 200)).not.toThrow();
+    expect(() => assert.notEqual(NaN, NaN)).not.toThrow();
+  });
+
+  it('should throw if a === b', () => {
+    expect(() => assert.notEqual('bar', 'bar')).toThrowError(
+      assert.AssertionError
+    );
+  });
+
+  it('should compare shallowly', () => {
+    expect(() => assert.notEqual({}, {})).not.toThrow();
+    expect(() => assert.notEqual([1, 2, 3], [1, 2, 3])).not.toThrow();
+  });
+});
+
+describe('assert.isAtLeast()', () => {
+  it('should not throw if a >= b', () => {
+    expect(() => assert.isAtLeast(15, 15)).not.toThrow();
+    expect(() => assert.isAtLeast(0, -1)).not.toThrow();
+    expect(() => assert.isAtLeast('Z', 'Z')).not.toThrow();
+    expect(() => assert.isAtLeast('Z', 'Y')).not.toThrow();
+  });
+
+  it('should throw if a < b', () => {
+    expect(() => assert.isAtLeast(10, 20)).toThrowError(assert.AssertionError);
+    expect(() => assert.isAtLeast('Y', 'Z')).toThrowError(
+      assert.AssertionError
+    );
+  });
+
+  it('should throw if two values cannot be compared', () => {
+    expect(() => assert.isAtLeast(1, NaN)).toThrowError(assert.AssertionError);
+  });
+});
+
+describe('assert.isAtMost()', () => {
+  it('should not throw if a <= b', () => {
+    expect(() => assert.isAtMost(0, 0)).not.toThrow();
+    expect(() => assert.isAtMost(-1, 0)).not.toThrow();
+    expect(() => assert.isAtMost('A', 'A')).not.toThrow();
+    expect(() => assert.isAtMost('A', 'B')).not.toThrow();
+  });
+
+  it('should throw if a > b', () => {
+    expect(() => assert.isAtMost(99, 88)).toThrowError(assert.AssertionError);
+    expect(() => assert.isAtMost('B', 'A')).toThrowError(assert.AssertionError);
+  });
+
+  it('should throw if two values cannot be compared', () => {
+    expect(() => assert.isAtMost(1, NaN)).toThrowError(assert.AssertionError);
+  });
+});
+
+describe('assert.isAbove()', () => {
+  it('should not throw if a > b', () => {
+    expect(() => assert.isAbove(0, -1)).not.toThrow();
+    expect(() => assert.isAbove('z', 'y')).not.toThrow();
+  });
+
+  it('should throw if a <= b', () => {
+    expect(() => assert.isAbove(40, 50)).toThrowError(assert.AssertionError);
+    expect(() => assert.isAbove(35, 35)).toThrowError(assert.AssertionError);
+    expect(() => assert.isAbove('y', 'y')).toThrowError(assert.AssertionError);
+    expect(() => assert.isAbove('x', 'y')).toThrowError(assert.AssertionError);
+  });
+
+  it('should throw if two values cannot be compared', () => {
+    expect(() => assert.isAbove(1, NaN)).toThrowError(assert.AssertionError);
+  });
+});
+
+describe('assert.isBelow()', () => {
+  it('should not throw if a < b', () => {
+    expect(() => assert.isBelow(-1, 0)).not.toThrow();
+    expect(() => assert.isBelow('a', 'b')).not.toThrow();
+  });
+
+  it('should throw if a >= b', () => {
+    expect(() => assert.isBelow(19, 7)).toThrowError(assert.AssertionError);
+    expect(() => assert.isBelow(12, 12)).toThrowError(assert.AssertionError);
+    expect(() => assert.isBelow('b', 'b')).toThrowError(assert.AssertionError);
+    expect(() => assert.isBelow('c', 'b')).toThrowError(assert.AssertionError);
+  });
+
+  it('should throw if two values cannot be compared', () => {
+    expect(() => assert.isBelow(1, NaN)).toThrowError(assert.AssertionError);
+  });
+});

--- a/src/assert/index.ts
+++ b/src/assert/index.ts
@@ -1,0 +1,116 @@
+/**
+ * @file Simple assertion tools.
+ * Note: This module does not rely on KoLmafia's JavaScript API, and can be used
+ * in any environment.
+ */
+
+/**
+ * Thrown when an assertion fails.
+ */
+export class AssertionError extends Error {
+  constructor(message = 'Assertion failure') {
+    super(message);
+    this.message = message;
+  }
+}
+
+AssertionError.prototype.name = 'AssertionError';
+
+/**
+ * Assert that the condition is truthy.
+ * @param cond Condition to check
+ * @param message Assertion message
+ */
+export function ok(cond: unknown, message?: string): asserts cond {
+  if (!cond) {
+    throw new AssertionError(message ?? `Condition is ${cond}`);
+  }
+}
+
+/**
+ * Always throw an exception.
+ * @param message Assertion message
+ */
+export function fail(message = 'Assertion failure'): never {
+  throw new AssertionError(message);
+}
+
+/**
+ * Assert that the two values are strictly equal (`===`).
+ * @param actual Value to check
+ * @param expected Expected value
+ * @param message Assertion message
+ */
+export function equal<T>(
+  actual: unknown,
+  expected: T,
+  message?: string
+): asserts actual is T {
+  if (actual !== expected) {
+    throw new AssertionError(message ?? `Expected ${actual} === ${expected}`);
+  }
+}
+
+/**
+ * Assert that the two values are strictly inequal (`!==`).
+ * @param actual Value to check
+ * @param expected Expected value
+ * @param message Assertion message
+ */
+export function notEqual(
+  actual: unknown,
+  expected: unknown,
+  message?: string
+): void {
+  if (actual === expected) {
+    throw new AssertionError(message ?? `Expected ${actual} !== ${expected}`);
+  }
+}
+
+/**
+ * Assert that the first value is same or greater than (`>=`) the second value.
+ * @param value Value to check
+ * @param atLeast Value to compare with
+ * @param message Assertion message
+ */
+export function isAtLeast<T>(value: T, atLeast: T, message?: string): void {
+  if (!(value >= atLeast)) {
+    throw new AssertionError(message ?? `Expected ${value} >= ${atLeast}`);
+  }
+}
+
+/**
+ * Assert that the first value is same or less than (`<=`) the second value.
+ * @param value Value to check
+ * @param atMost Value to compare with
+ * @param message Assertion message
+ */
+export function isAtMost<T>(value: T, atMost: T, message?: string): void {
+  if (!(value <= atMost)) {
+    throw new AssertionError(message ?? `Expected ${value} <= ${atMost}`);
+  }
+}
+
+/**
+ * Assert that the first value is greater than (`>`) the second value.
+ * @param value Value to check
+ * @param above Value to compare with
+ * @param message Assertion message
+ */
+export function isAbove<T>(value: T, above: T, message?: string): void {
+  if (!(value > above)) {
+    throw new AssertionError(message ?? `Expected ${value} > ${above}`);
+  }
+}
+
+/**
+ * Assert that the first value is less than (`<`) the second value.
+ * @param value Value to check
+ * @param below Value to compare with
+ * @param message Assertion message
+ */
+export function isBelow<T>(value: T, below: T, message?: string): void {
+  if (!(value < below)) {
+    throw new AssertionError(message ?? `Expected ${value} < ${below}`);
+  }
+}


### PR DESCRIPTION
Add basic assertion functions that were inspired by Node.js' [assert](https://nodejs.org/api/assert.html) module, as well as [Chai](https://www.chaijs.com/).

These functions are exposed as an 'assertion library' that must be imported from `kolmafia-util/assert`. They are _not_ exposed via the `kolmafia-util` path. Note that these assertion functions do not rely on KoLmafia's standard library, and can be used in any JavaScript environment, including the browser.

BREAKING CHANGE: To support this, we use the `exports` field of `package.json`, which is supported by Node.js >= 12.16.0 || >= 13.7.0 and prevents diving into the `node_modules/kolmafia-utils/build/` directory. As such, this is a breaking change.